### PR TITLE
Update to new cert-manager.io API group and formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,18 @@ While it's probably stable, you should treat it as prototype-quality.
 We will make reasonable efforts to avoid breaking changes (including renaming or otherwise altering metrics), but can't promise anything at this time.
 
 _Additionally_, this re-uses the service account and role bindings from cert-manager.
-This is (in the current implementation) necessary to read the certificates to parse their expiration dates.
+~~This is (in the current implementation) necessary to read the certificates to parse their expiration dates.~~ This needs to be updated, since only access to the Certificate resources are necessary (which do _not_ contain private keys).
 However, that does mean that **by default it has pretty deep access to Kubernetes resources, including secrets** (which is where the certificates are stored).
 A future version should reduce the access requirements, but like anything else you should be weary about deploying third-party code that is being granted access to Kubernetes resources.
 
 ## Quick Start
 
-This assumes you already have cert-manager up and running, inside the recommended `cert-manager` namespace with its RBAC settings.
-Further, this deployment uses Datadog's autodiscovery to have data scraped with Prometheus.
+Requirements:
+
+- `cert-manager` at v0.11.0 or later, deployed to your cluster (for older versions, use certamanager-metrics v0.0.3 or earlier)
+- Basic familiarity with Prometheus scraping configuration
+
+The following example uses Datadog's autodiscovery to scrape the Prometheus metrics.
 Other Prometheus auto-discovery should be easy to configure, and we welcome contributions to improve this.
 
 Apply the following deployment manifest:

--- a/src/Tools/CertScraper.php
+++ b/src/Tools/CertScraper.php
@@ -19,11 +19,11 @@ class CertScraper
      */
     public function getAllCertificates(): array
     {
-        $version = $this->api->get('/apis/certmanager.k8s.io')['preferredVersion']['version'];
-        $base = sprintf('/apis/certmanager.k8s.io/%s', $version);
+        $version = $this->api->get('/apis/cert-manager.io')['preferredVersion']['version'];
+        $base = sprintf('/apis/cert-manager.io/%s', $version);
         $certs = $this->api->get($base.'/certificates')['items'];
         return array_map(function ($cert) {
-            return new Certificate($this->api, $cert);
+            return new Certificate($cert);
         }, $certs);
     }
 

--- a/src/Tools/Certificate.php
+++ b/src/Tools/Certificate.php
@@ -12,58 +12,25 @@ use Kubernetes\Api;
  */
 class Certificate
 {
-    /** @var Api */
-    private $api;
-
     /** @var array K8s Cert object */
     private $k8sCert;
-
-    /** @var string actual cert, in pem format */
-    private $cert;
 
     /**
      * @param Api $api Kubernetes API connection
      * @param array $cert Kubernetes certificate object
      */
-    public function __construct(Api $api, array $cert)
+    public function __construct(array $cert)
     {
-        $this->api = $api;
         $this->k8sCert = $cert;
     }
 
     public function getInfo(): array
     {
-        $certInfo = openssl_x509_parse($this->getCertificate());
-
         return [
             'domains' => $this->k8sCert['spec']['dnsNames'],
-            'expires_at' => $certInfo['validTo_time_t'],
+            'expires_at' => strtotime($this->k8sCert['status']['notAfter']),
             'kube_namespace' => $this->k8sCert['metadata']['namespace'],
             'kube_certificate' => $this->k8sCert['metadata']['name'],
         ];
-    }
-
-    /**
-     * Returns the certificate, in PEM format. May fetch from an external
-     * source.
-     */
-    private function getCertificate()
-    {
-        if (!$this->cert) {
-            // This fetches from the secret. This is sub-optimal from
-            // a security standpoint since it requires additional permission
-            // grants, but should be both faster and less dependent on the
-            // external network.
-            // At some point this should be revisited in order to reduce the
-            // required permissions for the deployment role
-            $secretUrl = sprintf(
-                '/api/v1/namespaces/%s/secrets/%s',
-                $this->k8sCert['metadata']['namespace'],
-                $this->k8sCert['metadata']['name']
-            );
-            $secret = $this->api->get($secretUrl);
-            $this->cert = base64_decode($secret['data']['tls.crt']);
-        }
-        return $this->cert;
     }
 }


### PR DESCRIPTION
This updates the internals to use the API group changes in cert-manager v0.11.0 (`certmanager.k8s.io` -> `cert-manager.io`). A pleasant side-effect is that certificate parsing no longer needs to occur, which increases both security and performance.

Fixes #4 